### PR TITLE
Add chrom regex filter

### DIFF
--- a/wdl/gwas/saige.json
+++ b/wdl/gwas/saige.json
@@ -19,6 +19,7 @@
     "saige.test_combine.test.minmac": 5,
     "saige.test_combine.test.logP": true,
     "saige.test_combine.combine.logP": true,
+    "saige.test_combine.combine.chrom_regex": "chr[0-9]{1,2}",
 
     "saige.test_combine.combine.prefix": "finngen_R7_",
     "saige.test_combine.combine.chrcol": "#chrom",

--- a/wdl/gwas/saige_sub.wdl
+++ b/wdl/gwas/saige_sub.wdl
@@ -80,6 +80,7 @@ task combine {
     String prefix
     Boolean logP
     String logPStr = if logP then "True" else "False"
+    String chrom_regex
 
     command <<<
         set -euxo pipefail
@@ -91,6 +92,7 @@ task combine {
         |awk 'NR == 1; NR > 1 {print $0 | "sort -k 1,1V -k 2,2g"}' \
         |awk 'NR==1 { for(i=1;i<=NF;i++) { h[$i]=i }; if (! "POS" in h) { print "ERROR: POS not in saige file header"; exit 1};print } NR>1{ $h["POS"]=sprintf("%d",$h["POS"]);print $0 }' \
         |tr ' ' '\t' \
+        |grep -E "(^${chrom_regex})|(^CHR)"
         |bgzip > ${prefix}${pheno}.saige.gz
         tabix -s1 -b2 -e2 -S1 ${prefix}${pheno}.saige.gz
 

--- a/wdl/gwas/saige_tests.json
+++ b/wdl/gwas/saige_tests.json
@@ -12,7 +12,7 @@
     "saige.test_combine.test.minmac": 5,
     "saige.test_combine.test.logP": true,
     "saige.test_combine.combine.logP": true,
-    "saige.test_combine.combine.chrom_regex": "chr[0-9]{1,2}",
+    "saige.test_combine.combine.chrom_regex": "chr([0-9]{1,2})|(XYM)\s",
 
     "saige.test_combine.combine.prefix": "",
     "saige.test_combine.combine.chrcol": "#chrom",

--- a/wdl/gwas/saige_tests.json
+++ b/wdl/gwas/saige_tests.json
@@ -12,10 +12,11 @@
     "saige.test_combine.test.minmac": 5,
     "saige.test_combine.test.logP": true,
     "saige.test_combine.combine.logP": true,
+    "saige.test_combine.combine.chrom_regex": "chr[0-9]{1,2}",
 
     "saige.test_combine.combine.prefix": "",
     "saige.test_combine.combine.chrcol": "#chrom",
     "saige.test_combine.combine.p_valcol": "pval",
     "saige.test_combine.combine.bp_col": "pos",
-    "saige.test_combine.combine.loglog_pval": 10,
+    "saige.test_combine.combine.loglog_pval": 10
 }


### PR DESCRIPTION
Sometimes the data contains some odd contigs. Added an input to the saige_sub.wdl to filter chromosomes based on a regex (saige.test_combine.combine.chrom_regex), which by default should be `chr([0-9]{1,2})|(XYM)\s` to include chr1-22, chrX, chrY, chrM.